### PR TITLE
Add Plonkish structs in new speedyspartan module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,3 +21,4 @@ pub mod math;
 pub mod transcript;
 mod kzh3_verifier_circuit;
 mod kzh3_augmented_circuit;
+pub mod speedyspartan;

--- a/src/speedyspartan/mod.rs
+++ b/src/speedyspartan/mod.rs
@@ -1,0 +1,1 @@
+pub mod plonkish;

--- a/src/speedyspartan/plonkish.rs
+++ b/src/speedyspartan/plonkish.rs
@@ -1,0 +1,47 @@
+use ark_ec::CurveGroup;
+use ark_ff::PrimeField;
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+
+use crate::commitment::Commitment;
+use crate::polynomial::multilinear_poly::multilinear_poly::MultilinearPolynomial;
+use core::marker::PhantomData;
+
+#[derive(Clone, Debug, PartialEq, Eq, CanonicalSerialize, CanonicalDeserialize)]
+pub struct PlonkishShape<F: PrimeField> {
+    pub q_l: MultilinearPolynomial<F>,
+    pub q_r: MultilinearPolynomial<F>,
+    pub q_m: MultilinearPolynomial<F>,
+    pub q_o: MultilinearPolynomial<F>,
+    pub q_c: MultilinearPolynomial<F>,
+    pub A: Vec<usize>,
+    pub B: Vec<usize>,
+    pub C: Vec<usize>,
+    pub addr_A: Vec<MultilinearPolynomial<F>>,
+    pub addr_B: Vec<MultilinearPolynomial<F>>,
+    pub addr_C: Vec<MultilinearPolynomial<F>>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, CanonicalSerialize, CanonicalDeserialize)]
+pub struct PlonkishWitness<F: PrimeField> {
+    pub witness_data: Vec<F>,
+    pub witness_polynomial: MultilinearPolynomial<F>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, CanonicalSerialize, CanonicalDeserialize)]
+pub struct PlonkishCommitments<G: CurveGroup, C: Commitment<G>> {
+    pub q_l: C,
+    pub q_r: C,
+    pub q_m: C,
+    pub q_o: C,
+    pub q_c: C,
+    pub addr_A: Vec<C>,
+    pub addr_B: Vec<C>,
+    pub addr_C: Vec<C>,
+    pub(crate) _marker: PhantomData<G>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, CanonicalSerialize, CanonicalDeserialize)]
+pub struct PlonkishInstance<F: PrimeField, G: CurveGroup, C: Commitment<G>> {
+    pub instance: Vec<F>,
+    pub commitments: PlonkishCommitments<G, C>,
+}


### PR DESCRIPTION
## Summary
- add `speedyspartan` module and `plonkish` submodule
- introduce Plonkish shape, witness, commitments, and instance structs

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c0cc5971788330a9e824af796b7c6a