### PR TITLE
Expose secondary circuit builders in Nova flow

### DIFF
--- a/src/nova/nova/prover.rs
+++ b/src/nova/nova/prover.rs
@@ -1,10 +1,16 @@
-use crate::kzh2_verifier_circuit::affine_to_projective;
 use crate::commitment::{Commitment, CommitmentScheme};
 use crate::gadgets::non_native::util::cast_field;
-use crate::gadgets::r1cs::conversion::{convert_constraint_system_into_instance_witness, get_random_r1cs_instance_witness, get_random_relaxed_r1cs_instance_witness};
+use crate::gadgets::r1cs::conversion::{
+    convert_constraint_system_into_instance_witness, get_random_r1cs_instance_witness,
+    get_random_relaxed_r1cs_instance_witness,
+};
 use crate::gadgets::r1cs::ova::commit_T as Ova_commit_T;
 use crate::gadgets::r1cs::r1cs::commit_T as R1CS_commit_T;
-use crate::gadgets::r1cs::{OvaInstance, OvaWitness, R1CSInstance, R1CSShape, R1CSWitness, RelaxedOvaInstance, RelaxedOvaWitness, RelaxedR1CSInstance, RelaxedR1CSWitness};
+use crate::gadgets::r1cs::{
+    OvaInstance, OvaWitness, R1CSInstance, R1CSShape, R1CSWitness, RelaxedOvaInstance,
+    RelaxedOvaWitness, RelaxedR1CSInstance, RelaxedR1CSWitness,
+};
+use crate::kzh2_verifier_circuit::affine_to_projective;
 use crate::nova::cycle_fold::coprocessor::{setup_shape, synthesize, SecondaryCircuit};
 use crate::nova::nova::get_affine_coords;
 use crate::transcript::transcript::Transcript;
@@ -12,20 +18,20 @@ use ark_crypto_primitives::sponge::Absorb;
 use ark_ec::short_weierstrass::{Affine, Projective, SWCurveConfig};
 use ark_ec::{CurveConfig, CurveGroup};
 use ark_ff::PrimeField;
-use ark_relations::r1cs::ConstraintSystemRef;
+use ark_relations::r1cs::{ConstraintSystemRef, SynthesisError};
 use rand::thread_rng;
 
 #[derive(Clone)]
 pub struct NovaProver<F, G1, G2, C1, C2>
 where
     F: PrimeField + Absorb,
-    G1: SWCurveConfig<BaseField=G2::ScalarField, ScalarField=G2::BaseField> + Clone,
+    G1: SWCurveConfig<BaseField = G2::ScalarField, ScalarField = G2::BaseField> + Clone,
     G1::BaseField: PrimeField,
     G1::ScalarField: PrimeField,
-    G2: SWCurveConfig<BaseField=F>,
+    G2: SWCurveConfig<BaseField = F>,
     G2::BaseField: PrimeField,
-    C1: CommitmentScheme<Projective<G1>, PP=Vec<Affine<G1>>>,
-    C2: CommitmentScheme<Projective<G2>, PP=Vec<Affine<G2>>>,
+    C1: CommitmentScheme<Projective<G1>, PP = Vec<Affine<G1>>>,
+    C2: CommitmentScheme<Projective<G2>, PP = Vec<Affine<G2>>>,
     <G2 as CurveConfig>::ScalarField: Absorb,
 {
     /// shape of the main curve
@@ -50,23 +56,30 @@ where
 impl<F, G1, G2, C1, C2> NovaProver<F, G1, G2, C1, C2>
 where
     F: PrimeField + Absorb,
-    G1: SWCurveConfig<BaseField=G2::ScalarField, ScalarField=G2::BaseField> + Clone,
+    G1: SWCurveConfig<BaseField = G2::ScalarField, ScalarField = G2::BaseField> + Clone,
     G1::BaseField: PrimeField,
     G1::ScalarField: PrimeField,
-    G2: SWCurveConfig<BaseField=F>,
+    G2: SWCurveConfig<BaseField = F>,
     G2::BaseField: PrimeField,
-    C1: CommitmentScheme<Projective<G1>, PP=Vec<Affine<G1>>, Commitment=Projective<G1>, SetupAux=()>,
-    C2: CommitmentScheme<Projective<G2>, PP=Vec<Affine<G2>>, SetupAux=()>,
+    C1: CommitmentScheme<
+        Projective<G1>,
+        PP = Vec<Affine<G1>>,
+        Commitment = Projective<G1>,
+        SetupAux = (),
+    >,
+    C2: CommitmentScheme<Projective<G2>, PP = Vec<Affine<G2>>, SetupAux = ()>,
     <G2 as CurveConfig>::ScalarField: Absorb,
 {
     pub fn compute_nova_cross_term_error(&self) -> Projective<G1> {
-        let (_, com_t) = R1CS_commit_T(&self.shape,
-                                       &self.commitment_pp,
-                                       &self.running_accumulator.0,
-                                       &self.running_accumulator.1,
-                                       &self.current_accumulator.0,
-                                       &self.current_accumulator.1,
-        ).unwrap();
+        let (_, com_t) = R1CS_commit_T(
+            &self.shape,
+            &self.commitment_pp,
+            &self.running_accumulator.0,
+            &self.running_accumulator.1,
+            &self.current_accumulator.0,
+            &self.current_accumulator.1,
+        )
+        .unwrap();
 
         com_t
     }
@@ -78,8 +91,20 @@ where
 
         // make a new transcript and add with the following order: running accumulator instance + current accumulator instance + cross term error
         let mut transcript = Transcript::new(b"new transcript");
-        transcript.append_scalars(b"label", self.running_accumulator.0.to_sponge_field_elements().as_slice());
-        transcript.append_scalars(b"label", self.current_accumulator.0.to_sponge_field_elements().as_slice());
+        transcript.append_scalars(
+            b"label",
+            self.running_accumulator
+                .0
+                .to_sponge_field_elements()
+                .as_slice(),
+        );
+        transcript.append_scalars(
+            b"label",
+            self.current_accumulator
+                .0
+                .to_sponge_field_elements()
+                .as_slice(),
+        );
         transcript.append_scalars_non_native(b"label", &[com_T_x, com_T_y]);
 
         // derive the challenge
@@ -89,7 +114,67 @@ where
         (beta, transcript)
     }
 
-    pub fn compute_final_accumulator(&self, beta: &F) -> (RelaxedR1CSInstance<G1, C1>, RelaxedR1CSWitness<G1>, Projective<G1>) {
+    fn ova_witness_srs(&self) -> Vec<Affine<G2>> {
+        self.ova_commitment_pp[0..self.ova_shape.num_vars].to_vec()
+    }
+
+    fn ova_commitment_srs(&self) -> Vec<Affine<G2>> {
+        self.ova_commitment_pp[self.ova_shape.num_vars..].to_vec()
+    }
+
+    pub fn synthesize_secondary_circuit(
+        &self,
+        circuit: SecondaryCircuit<G1>,
+    ) -> Result<(OvaInstance<G2, C2>, OvaWitness<G2>), SynthesisError> {
+        synthesize::<G1, G2, C2>(circuit, &self.ova_witness_srs())
+    }
+
+    pub fn synthesize_secondary_with<Build>(
+        &self,
+        build: Build,
+    ) -> Result<(OvaInstance<G2, C2>, OvaWitness<G2>), SynthesisError>
+    where
+        Build: FnOnce(&Self) -> SecondaryCircuit<G1>,
+    {
+        self.synthesize_secondary_circuit(build(self))
+    }
+
+    pub fn build_ova_auxiliary_input_W(&self, beta: &F) -> SecondaryCircuit<G1> {
+        let g1 = affine_to_projective(self.current_accumulator.0.commitment_W.into());
+        let g2 = affine_to_projective(self.running_accumulator.0.commitment_W.into());
+        let g_out = (g1 * beta) + g2;
+
+        SecondaryCircuit {
+            g1,
+            g2,
+            g_out,
+            r: cast_field::<G1::ScalarField, G1::BaseField>(*beta),
+            flag: true,
+        }
+    }
+
+    pub fn build_ova_auxiliary_input_E(&self, beta: &F) -> SecondaryCircuit<G1> {
+        let g1 = self.compute_nova_cross_term_error();
+        let g2 = affine_to_projective(self.running_accumulator.0.commitment_E.into());
+        let g_out = (g1 * beta) + g2;
+
+        SecondaryCircuit {
+            g1,
+            g2,
+            g_out,
+            r: cast_field::<G1::ScalarField, G1::BaseField>(*beta),
+            flag: true,
+        }
+    }
+
+    pub fn compute_final_accumulator(
+        &self,
+        beta: &F,
+    ) -> (
+        RelaxedR1CSInstance<G1, C1>,
+        RelaxedR1CSWitness<G1>,
+        Projective<G1>,
+    ) {
         let (nova_cross_term_error, nova_cross_term_error_commitment) = R1CS_commit_T(
             &self.shape,
             &self.commitment_pp,
@@ -97,141 +182,170 @@ where
             &self.running_accumulator.1,
             &self.current_accumulator.0,
             &self.current_accumulator.1,
-        ).unwrap();
+        )
+        .unwrap();
 
         // folding two instances
-        let folded_instance = self.running_accumulator.0.fold(
-            &self.current_accumulator.0,
-            &nova_cross_term_error_commitment,
-            &beta,
-        ).unwrap();
+        let folded_instance = self
+            .running_accumulator
+            .0
+            .fold(
+                &self.current_accumulator.0,
+                &nova_cross_term_error_commitment,
+                &beta,
+            )
+            .unwrap();
 
         // folding two witnesses
-        let folded_witness = self.running_accumulator.1.fold(
-            &self.current_accumulator.1,
-            &nova_cross_term_error,
-            &beta,
-        ).unwrap();
+        let folded_witness = self
+            .running_accumulator
+            .1
+            .fold(&self.current_accumulator.1, &nova_cross_term_error, &beta)
+            .unwrap();
 
-        (folded_instance, folded_witness, nova_cross_term_error_commitment)
+        (
+            folded_instance,
+            folded_witness,
+            nova_cross_term_error_commitment,
+        )
     }
 
     pub fn compute_ova_auxiliary_input_E(&self, beta: &F) -> (OvaInstance<G2, C2>, OvaWitness<G2>) {
-        let g1 = self.compute_nova_cross_term_error();
-        let g2 = affine_to_projective(self.running_accumulator.0.commitment_E.into());
-
-        let g_out = (g1 * beta) + g2;
-
-        synthesize::<G1, G2, C2>(SecondaryCircuit {
-            g1,
-            g2,
-            g_out,
-            r: cast_field::<G1::ScalarField, G1::BaseField>(*beta),
-            flag: true,
-        }, &self.ova_commitment_pp[0..self.ova_shape.num_vars].to_vec()).unwrap()
+        self.synthesize_secondary_circuit(self.build_ova_auxiliary_input_E(beta))
+            .expect("secondary circuit synthesis should not fail")
     }
 
     pub fn compute_ova_auxiliary_input_W(&self, beta: &F) -> (OvaInstance<G2, C2>, OvaWitness<G2>) {
-        let g1 = affine_to_projective(self.current_accumulator.0.commitment_W.into());
-        let g2 = affine_to_projective(self.running_accumulator.0.commitment_W.into());
-        let g_out = (g1 * beta) + g2;
-
-        synthesize::<G1, G2, C2>(SecondaryCircuit {
-            g1,
-            g2,
-            g_out,
-            r: cast_field::<G1::ScalarField, G1::BaseField>(*beta),
-            flag: true,
-        }, &self.ova_commitment_pp[0..self.ova_shape.num_vars].to_vec()).unwrap()
+        self.synthesize_secondary_circuit(self.build_ova_auxiliary_input_W(beta))
+            .expect("secondary circuit synthesis should not fail")
     }
 
-    pub fn compute_ova_final_instance(&self) -> ((RelaxedOvaInstance<G2, C2>, RelaxedOvaWitness<G2>), (C2::Commitment, C2::Commitment), (F, F)) {
-        // get the random challenge beta
-        let (beta, mut transcript) = self.compute_beta();
+    pub fn compute_ova_final_instance_from_circuits(
+        &self,
+        beta: F,
+        mut transcript: Transcript<F>,
+        circuit_w: SecondaryCircuit<G1>,
+        circuit_e: SecondaryCircuit<G1>,
+    ) -> Result<
+        (
+            (RelaxedOvaInstance<G2, C2>, RelaxedOvaWitness<G2>),
+            (C2::Commitment, C2::Commitment),
+            (F, F),
+        ),
+        SynthesisError,
+    > {
+        let (ova_instance_w, ova_witness_w) = self.synthesize_secondary_circuit(circuit_w)?;
 
-        // get the ova instance/witness for computing the new witness
-        let (ova_instance_w, ova_witness_w) = self.compute_ova_auxiliary_input_W(&beta);
-
-        // get the cross term proof
         let (cross_term_error_w, cross_term_error_commitment_w) = Ova_commit_T(
             &self.ova_shape,
-            &self.ova_commitment_pp[self.ova_shape.num_vars..].to_vec(),
+            &self.ova_commitment_srs(),
             &self.ova_running_instance,
             &self.ova_running_witness,
             &ova_instance_w,
             &ova_witness_w,
-        ).unwrap();
+        )
+        .map_err(|_| SynthesisError::AssignmentMissing)?;
 
-        // add the new cross term error to the transcript
-        let coordinates = get_affine_coords::<G2::BaseField, G2>(&cross_term_error_commitment_w.into_affine());
-        transcript.append_scalars(b"add scalars", &[
-            coordinates.0,
-            coordinates.1,
-        ]);
+        let coordinates =
+            get_affine_coords::<G2::BaseField, G2>(&cross_term_error_commitment_w.into_affine());
+        transcript.append_scalars(b"add scalars", &[coordinates.0, coordinates.1]);
 
-        // derive beta_1
         let beta_1 = transcript.challenge_scalar(b"challenge");
-
-        // currently we use the same beta as randomness, this can later change
         let beta_1_non_native = cast_field::<G1::ScalarField, G1::BaseField>(beta_1);
 
-        // compute the folded instance and folded witness
-        let folded_instance = self.ova_running_instance.fold(
-            &ova_instance_w,
-            &cross_term_error_commitment_w,
-            &beta_1_non_native,
-        ).expect("folding instance error");
+        let folded_instance = self
+            .ova_running_instance
+            .fold(
+                &ova_instance_w,
+                &cross_term_error_commitment_w,
+                &beta_1_non_native,
+            )
+            .expect("folding instance error");
 
-        let folded_witness = self.ova_running_witness.fold(
-            &ova_witness_w,
-            &cross_term_error_w,
-            &beta_1_non_native,
-        ).expect("folding witness error");
+        let folded_witness = self
+            .ova_running_witness
+            .fold(&ova_witness_w, &cross_term_error_w, &beta_1_non_native)
+            .expect("folding witness error");
 
-        // compute ova instance / witness for the error term
-        let (ova_instance_e, ova_witness_e) = self.compute_ova_auxiliary_input_E(&beta);
+        let (ova_instance_e, ova_witness_e) = self.synthesize_secondary_circuit(circuit_e)?;
 
-        // compute the cross term error
         let (cross_term_error_e, cross_term_error_commitment_e) = Ova_commit_T(
             &self.ova_shape,
-            &self.ova_commitment_pp[self.ova_shape.num_vars..].to_vec(),
+            &self.ova_commitment_srs(),
             &folded_instance,
             &folded_witness,
             &ova_instance_e,
             &ova_witness_e,
-        ).unwrap();
+        )
+        .map_err(|_| SynthesisError::AssignmentMissing)?;
 
-        // add the new cross term error to the transcript
-        let coordinates = get_affine_coords::<G2::BaseField, G2>(&cross_term_error_commitment_e.into_affine());
-        transcript.append_scalars(b"add scalars", &[
-            coordinates.0,
-            coordinates.1,
-        ]);
+        let coordinates =
+            get_affine_coords::<G2::BaseField, G2>(&cross_term_error_commitment_e.into_affine());
+        transcript.append_scalars(b"add scalars", &[coordinates.0, coordinates.1]);
 
-        // derive beta_2
         let beta_2 = transcript.challenge_scalar(b"challenge");
-
-        // currently we use the same beta as randomness, this can later change
         let beta_2_non_native = cast_field::<G1::ScalarField, G1::BaseField>(beta_2);
 
-        // compute the next folded instance / witness
-        let final_folded_instance = folded_instance.fold(
-            &ova_instance_e,
-            &cross_term_error_commitment_e,
-            &beta_2_non_native,
-        ).expect("folding instance error");
+        let final_folded_instance = folded_instance
+            .fold(
+                &ova_instance_e,
+                &cross_term_error_commitment_e,
+                &beta_2_non_native,
+            )
+            .expect("folding instance error");
 
-        let final_folded_witness = folded_witness.fold(
-            &ova_witness_e,
-            &cross_term_error_e,
-            &beta_2_non_native,
-        ).expect("folding witness error");
+        let final_folded_witness = folded_witness
+            .fold(&ova_witness_e, &cross_term_error_e, &beta_2_non_native)
+            .expect("folding witness error");
 
-        (
+        Ok((
             (final_folded_instance, final_folded_witness),
             (cross_term_error_commitment_w, cross_term_error_commitment_e),
-            (beta_1, beta_2)
+            (beta_1, beta_2),
+        ))
+    }
+
+    pub fn compute_ova_final_instance_with_secondary<BuildW, BuildE>(
+        &self,
+        beta: F,
+        transcript: Transcript<F>,
+        build_w: BuildW,
+        build_e: BuildE,
+    ) -> Result<
+        (
+            (RelaxedOvaInstance<G2, C2>, RelaxedOvaWitness<G2>),
+            (C2::Commitment, C2::Commitment),
+            (F, F),
+        ),
+        SynthesisError,
+    >
+    where
+        BuildW: Fn(&Self, &F) -> SecondaryCircuit<G1>,
+        BuildE: Fn(&Self, &F) -> SecondaryCircuit<G1>,
+    {
+        self.compute_ova_final_instance_from_circuits(
+            beta,
+            transcript,
+            build_w(self, &beta),
+            build_e(self, &beta),
         )
+    }
+
+    pub fn compute_ova_final_instance(
+        &self,
+    ) -> (
+        (RelaxedOvaInstance<G2, C2>, RelaxedOvaWitness<G2>),
+        (C2::Commitment, C2::Commitment),
+        (F, F),
+    ) {
+        let (beta, transcript) = self.compute_beta();
+        self.compute_ova_final_instance_with_secondary(
+            beta,
+            transcript,
+            Self::build_ova_auxiliary_input_W,
+            Self::build_ova_auxiliary_input_E,
+        )
+        .expect("cycle-fold synthesis should not fail")
     }
 
     pub fn rand(structure: (usize, usize, usize)) -> NovaProver<F, G1, G2, C1, C2> {
@@ -241,22 +355,38 @@ where
         let (num_constraints, num_io, num_vars) = structure;
 
         // get commitment_pp
-        let ova_commitment_pp: Vec<Affine<G2>> = C2::setup(ova_shape.num_vars + ova_shape.num_constraints, b"test", &());
+        let ova_commitment_pp: Vec<Affine<G2>> =
+            C2::setup(ova_shape.num_vars + ova_shape.num_constraints, b"test", &());
         let commitment_pp: Vec<Affine<G1>> = C1::setup(num_vars, b"test", &());
 
-        let (shape, instance, witness) = get_random_r1cs_instance_witness::<F, C1, G1>(num_constraints, num_vars, num_io, &commitment_pp);
+        let (shape, instance, witness) = get_random_r1cs_instance_witness::<F, C1, G1>(
+            num_constraints,
+            num_vars,
+            num_io,
+            &commitment_pp,
+        );
 
         // assert it's satisfied
-        shape.is_satisfied(&instance, &witness, &commitment_pp).expect("unsatisfied r1cs");
+        shape
+            .is_satisfied(&instance, &witness, &commitment_pp)
+            .expect("unsatisfied r1cs");
 
         // generate a relaxed instance/witness this time
-        let (relaxed_shape, relaxed_instance, relaxed_witness) = get_random_relaxed_r1cs_instance_witness::<F, C1, G1>(num_constraints, num_vars, num_io, &commitment_pp);
+        let (relaxed_shape, relaxed_instance, relaxed_witness) =
+            get_random_relaxed_r1cs_instance_witness::<F, C1, G1>(
+                num_constraints,
+                num_vars,
+                num_io,
+                &commitment_pp,
+            );
 
         // assert the shape is equal to the previous shape
         assert_eq!(shape, relaxed_shape);
 
         // make sure the instance is satisfied
-        shape.is_relaxed_satisfied(&relaxed_instance, &relaxed_witness, &commitment_pp).expect("unsatisfied r1cs");
+        shape
+            .is_relaxed_satisfied(&relaxed_instance, &relaxed_witness, &commitment_pp)
+            .expect("unsatisfied r1cs");
 
         NovaProver {
             shape,
@@ -270,12 +400,15 @@ where
         }
     }
 
-    pub fn rand_from_constraint_system(cs: ConstraintSystemRef<F>) -> NovaProver<F, G1, G2, C1, C2> {
+    pub fn rand_from_constraint_system(
+        cs: ConstraintSystemRef<F>,
+    ) -> NovaProver<F, G1, G2, C1, C2> {
         // the shape of the secondary curve R1CS instance
         let ova_shape = setup_shape::<G1, G2>().unwrap();
 
         // get commitment_pp
-        let ova_commitment_pp: Vec<Affine<G2>> = C2::setup(ova_shape.num_vars + ova_shape.num_constraints, b"test", &());
+        let ova_commitment_pp: Vec<Affine<G2>> =
+            C2::setup(ova_shape.num_vars + ova_shape.num_constraints, b"test", &());
         let commitment_pp: Vec<Affine<G1>> = C1::setup(cs.num_witness_variables(), b"test", &());
 
         let (shape, instance, witness) = convert_constraint_system_into_instance_witness::<F, C1, G1>(
@@ -284,16 +417,18 @@ where
         );
 
         // assert it's satisfied
-        shape.is_satisfied(&instance, &witness, &commitment_pp).expect("unsatisfied r1cs");
+        shape
+            .is_satisfied(&instance, &witness, &commitment_pp)
+            .expect("unsatisfied r1cs");
 
         // generate a relaxed instance/witness this time
-        let (relaxed_instance, relaxed_witness) = shape.random_relaxed_r1cs(
-            &commitment_pp,
-            &mut thread_rng(),
-        );
+        let (relaxed_instance, relaxed_witness) =
+            shape.random_relaxed_r1cs(&commitment_pp, &mut thread_rng());
 
         // make sure the instance is satisfied
-        shape.is_relaxed_satisfied(&relaxed_instance, &relaxed_witness, &commitment_pp).expect("unsatisfied r1cs");
+        shape
+            .is_relaxed_satisfied(&relaxed_instance, &relaxed_witness, &commitment_pp)
+            .expect("unsatisfied r1cs");
 
         NovaProver {
             shape,
@@ -308,14 +443,13 @@ where
     }
 }
 
-
 #[cfg(test)]
 mod test {
     use crate::constant_for_curves::{ScalarField, C1, C2, G1, G2};
-    use ark_serialize::CanonicalSerialize;
-    use ark_std::{UniformRand};
-    use rand::thread_rng;
     use crate::nova::nova::prover::NovaProver;
+    use ark_serialize::CanonicalSerialize;
+    use ark_std::UniformRand;
+    use rand::thread_rng;
 
     type F = ScalarField;
 
@@ -326,14 +460,27 @@ mod test {
         let beta = F::rand(&mut thread_rng());
         let folded_accumulator = prover.compute_final_accumulator(&beta);
 
-        prover.shape.is_relaxed_satisfied(&folded_accumulator.0, &folded_accumulator.1, &prover.commitment_pp).unwrap();
+        prover
+            .shape
+            .is_relaxed_satisfied(
+                &folded_accumulator.0,
+                &folded_accumulator.1,
+                &prover.commitment_pp,
+            )
+            .unwrap();
 
         let circuit_e = prover.compute_ova_auxiliary_input_E(&beta);
         let circuit_w = prover.compute_ova_auxiliary_input_W(&beta);
 
         // assert both instances are satisfied
-        prover.ova_shape.is_ova_satisfied(&circuit_e.0, &circuit_e.1, &prover.ova_commitment_pp).unwrap();
-        prover.ova_shape.is_ova_satisfied(&circuit_w.0, &circuit_w.1, &prover.ova_commitment_pp).unwrap();
+        prover
+            .ova_shape
+            .is_ova_satisfied(&circuit_e.0, &circuit_e.1, &prover.ova_commitment_pp)
+            .unwrap();
+        prover
+            .ova_shape
+            .is_ova_satisfied(&circuit_w.0, &circuit_w.1, &prover.ova_commitment_pp)
+            .unwrap();
 
         // make sure they're consistent with the folded_accumulator
         let secondary_circuit_W = circuit_w.0.parse_secondary_io::<G1>().unwrap();
@@ -341,10 +488,38 @@ mod test {
         let secondary_circuit_E = circuit_e.0.parse_secondary_io::<G1>().unwrap();
         assert_eq!(secondary_circuit_E.g_out, folded_accumulator.0.commitment_E);
 
-        let ((final_ova_instance, final_ova_witness), (_, _), (_, _)) = prover.compute_ova_final_instance();
-        prover.ova_shape.is_relaxed_ova_satisfied(&final_ova_instance, &final_ova_witness, &prover.ova_commitment_pp).unwrap();
+        let ((final_ova_instance, final_ova_witness), (_, _), (_, _)) =
+            prover.compute_ova_final_instance();
+        prover
+            .ova_shape
+            .is_relaxed_ova_satisfied(
+                &final_ova_instance,
+                &final_ova_witness,
+                &prover.ova_commitment_pp,
+            )
+            .unwrap();
 
-        println!("ova instance len: {} bytes", final_ova_instance.compressed_size());
-        println!("ova witness len: {} bytes", final_ova_witness.compressed_size());
+        println!(
+            "ova instance len: {} bytes",
+            final_ova_instance.compressed_size()
+        );
+        println!(
+            "ova witness len: {} bytes",
+            final_ova_witness.compressed_size()
+        );
+    }
+
+    #[test]
+    fn test_secondary_synthesis_builder() {
+        let prover: NovaProver<F, G1, G2, C1, C2> = NovaProver::rand((4, 3, 10));
+        let beta = F::rand(&mut thread_rng());
+
+        let (default_instance, _) = prover.compute_ova_auxiliary_input_W(&beta);
+        let (custom_instance, _) = prover
+            .synthesize_secondary_with(|p| p.build_ova_auxiliary_input_W(&beta))
+            .expect("secondary synthesis should not fail");
+
+        assert_eq!(default_instance.commitment, custom_instance.commitment);
+        assert_eq!(default_instance.X, custom_instance.X);
     }
 }

--- a/src/nova/nova/verifier_circuit.rs
+++ b/src/nova/nova/verifier_circuit.rs
@@ -1,6 +1,7 @@
-use crate::commitment::{CommitmentScheme};
+use crate::commitment::CommitmentScheme;
 use crate::gadgets::non_native::util::cast_field;
 use crate::gadgets::r1cs::{OvaInstance, R1CSInstance, RelaxedOvaInstance, RelaxedR1CSInstance};
+use crate::nova::cycle_fold::coprocessor::SecondaryCircuit;
 use crate::nova::nova::get_affine_coords;
 use crate::nova::nova::prover::NovaProver;
 use crate::transcript::transcript::Transcript;
@@ -15,11 +16,21 @@ where
     G1: SWCurveConfig + Clone,
     G1::BaseField: PrimeField,
     G1::ScalarField: PrimeField + Absorb,
-    G2: SWCurveConfig<BaseField=F> + Clone,
+    G2: SWCurveConfig<BaseField = F> + Clone,
     G2::BaseField: PrimeField,
-    C1: CommitmentScheme<Projective<G1>, PP=Vec<Affine<G1>>, Commitment=Projective<G1>, SetupAux=()>,
-    C2: CommitmentScheme<Projective<G2>, PP=Vec<Affine<G2>>, Commitment=Projective<G2>, SetupAux=()>,
-    G1: SWCurveConfig<BaseField=G2::ScalarField, ScalarField=G2::BaseField>,
+    C1: CommitmentScheme<
+        Projective<G1>,
+        PP = Vec<Affine<G1>>,
+        Commitment = Projective<G1>,
+        SetupAux = (),
+    >,
+    C2: CommitmentScheme<
+        Projective<G2>,
+        PP = Vec<Affine<G2>>,
+        Commitment = Projective<G2>,
+        SetupAux = (),
+    >,
+    G1: SWCurveConfig<BaseField = G2::ScalarField, ScalarField = G2::BaseField>,
     F: PrimeField,
 {
     pub running_instance: RelaxedR1CSInstance<G1, C1>,
@@ -60,23 +71,39 @@ where
     G1: SWCurveConfig + Clone,
     G1::BaseField: PrimeField,
     G1::ScalarField: PrimeField + Absorb,
-    G2: SWCurveConfig<BaseField=F> + Clone,
+    G2: SWCurveConfig<BaseField = F> + Clone,
     G2::BaseField: PrimeField,
-    C1: CommitmentScheme<Projective<G1>, PP=Vec<Affine<G1>>, Commitment=Projective<G1>, SetupAux=()>,
-    C2: CommitmentScheme<Projective<G2>, PP=Vec<Affine<G2>>, Commitment=Projective<G2>, SetupAux=()>,
-    G1: SWCurveConfig<BaseField=G2::ScalarField, ScalarField=G2::BaseField>,
+    C1: CommitmentScheme<
+        Projective<G1>,
+        PP = Vec<Affine<G1>>,
+        Commitment = Projective<G1>,
+        SetupAux = (),
+    >,
+    C2: CommitmentScheme<
+        Projective<G2>,
+        PP = Vec<Affine<G2>>,
+        Commitment = Projective<G2>,
+        SetupAux = (),
+    >,
+    G1: SWCurveConfig<BaseField = G2::ScalarField, ScalarField = G2::BaseField>,
     F: PrimeField,
 {
     pub fn verify(&self) {
-        let expected_final_instance = self.running_instance.fold(
-            &self.current_instance,
-            &self.nova_cross_term_error,
-            &self.beta,
-        ).unwrap();
+        let expected_final_instance = self
+            .running_instance
+            .fold(
+                &self.current_instance,
+                &self.nova_cross_term_error,
+                &self.beta,
+            )
+            .unwrap();
 
         assert_eq!(expected_final_instance, self.final_instance);
 
-        let secondary_circuit_W = self.auxiliary_input_W_var.parse_secondary_io::<G1>().unwrap();
+        let secondary_circuit_W = self
+            .auxiliary_input_W_var
+            .parse_secondary_io::<G1>()
+            .unwrap();
 
         assert_eq!(secondary_circuit_W.r, self.beta_non_native);
         assert_eq!(secondary_circuit_W.g1, self.current_instance.commitment_W);
@@ -84,7 +111,10 @@ where
         assert_eq!(secondary_circuit_W.g_out, self.final_instance.commitment_W);
         assert_eq!(secondary_circuit_W.flag, true);
 
-        let secondary_circuit_E = self.auxiliary_input_E_var.parse_secondary_io::<G1>().unwrap();
+        let secondary_circuit_E = self
+            .auxiliary_input_E_var
+            .parse_secondary_io::<G1>()
+            .unwrap();
 
         assert_eq!(secondary_circuit_E.r, self.beta_non_native);
         assert_eq!(secondary_circuit_E.g1, self.nova_cross_term_error);
@@ -94,9 +124,21 @@ where
 
         let expected_final_cycle_fold_instance = {
             // fold the running cycle fold instance with auxiliary input W using randomness beta_1
-            let temp = self.running_ova_instance.fold(&self.auxiliary_input_W_var, &self.cross_term_error_commitment_w, &self.beta_1_non_native).expect("TODO: panic message");
+            let temp = self
+                .running_ova_instance
+                .fold(
+                    &self.auxiliary_input_W_var,
+                    &self.cross_term_error_commitment_w,
+                    &self.beta_1_non_native,
+                )
+                .expect("TODO: panic message");
             // fold the running cycle fold instance with auxiliary input E using randomness beta_2
-            temp.fold(&self.auxiliary_input_E_var, &self.cross_term_error_commitment_e, &self.beta_2_non_native).expect("TODO: panic message")
+            temp.fold(
+                &self.auxiliary_input_E_var,
+                &self.cross_term_error_commitment_e,
+                &self.beta_2_non_native,
+            )
+            .expect("TODO: panic message")
         };
 
         assert_eq!(expected_final_cycle_fold_instance, self.final_ova_instance);
@@ -104,8 +146,14 @@ where
         // compute beta
         let affine: Affine<G1> = CurveGroup::into_affine(self.nova_cross_term_error);
         let mut transcript = Transcript::new(b"new transcript");
-        transcript.append_scalars(b"label", &self.running_instance.to_sponge_field_elements().as_slice());
-        transcript.append_scalars(b"label", &self.current_instance.to_sponge_field_elements().as_slice());
+        transcript.append_scalars(
+            b"label",
+            &self.running_instance.to_sponge_field_elements().as_slice(),
+        );
+        transcript.append_scalars(
+            b"label",
+            &self.current_instance.to_sponge_field_elements().as_slice(),
+        );
         transcript.append_scalars_non_native(b"label", &[affine.x().unwrap(), affine.y().unwrap()]);
         let beta = transcript.challenge_scalar(b"challenge");
 
@@ -113,11 +161,10 @@ where
         assert_eq!(beta, cast_field::<G1::BaseField, F>(self.beta_non_native));
 
         // compute beta_1
-        let coordinates = get_affine_coords::<G2::BaseField, G2>(&CurveGroup::into_affine(self.cross_term_error_commitment_w));
-        transcript.append_scalars(b"add scalars", &[
-            coordinates.0,
-            coordinates.1,
-        ]);
+        let coordinates = get_affine_coords::<G2::BaseField, G2>(&CurveGroup::into_affine(
+            self.cross_term_error_commitment_w,
+        ));
+        transcript.append_scalars(b"add scalars", &[coordinates.0, coordinates.1]);
 
         // derive beta_1
         let beta_1 = transcript.challenge_scalar(b"challenge");
@@ -129,11 +176,10 @@ where
         assert_eq!(beta_1_non_native, self.beta_1_non_native);
 
         // compute beta_2
-        let coordinates = get_affine_coords::<G2::BaseField, G2>(&ark_ec::CurveGroup::into_affine(self.cross_term_error_commitment_e));
-        transcript.append_scalars(b"add scalars", &[
-            coordinates.0,
-            coordinates.1,
-        ]);
+        let coordinates = get_affine_coords::<G2::BaseField, G2>(&ark_ec::CurveGroup::into_affine(
+            self.cross_term_error_commitment_e,
+        ));
+        transcript.append_scalars(b"add scalars", &[coordinates.0, coordinates.1]);
 
         // derive beta_2
         let beta_2 = transcript.challenge_scalar(b"challenge");
@@ -145,18 +191,47 @@ where
         assert_eq!(beta_2_non_native, self.beta_2_non_native);
     }
 
-    pub fn initialise(prover: NovaProver<F, G1, G2, C1, C2>) -> NovaVerifierCircuit<F, G1, G2, C1, C2>
+    pub fn initialise_with_secondary<BuildW, BuildE>(
+        prover: NovaProver<F, G1, G2, C1, C2>,
+        build_w: BuildW,
+        build_e: BuildE,
+    ) -> NovaVerifierCircuit<F, G1, G2, C1, C2>
     where
         <G2 as CurveConfig>::ScalarField: Absorb,
+        BuildW: Fn(&NovaProver<F, G1, G2, C1, C2>, &F) -> SecondaryCircuit<G1>,
+        BuildE: Fn(&NovaProver<F, G1, G2, C1, C2>, &F) -> SecondaryCircuit<G1>,
     {
-        // we don't use the transcript output by prover.compute_beta() since function compute_final_ova_instance calls this internally
-        let (beta, _) = prover.compute_beta();
+        let (beta, transcript) = prover.compute_beta();
         let beta_non_native = cast_field::<G1::ScalarField, G1::BaseField>(beta);
         let (final_instance, _, nova_cross_term_error) = prover.compute_final_accumulator(&beta);
-        let ((final_cycle_fold_instance, _), (cross_term_error_commitment_w, cross_term_error_commitment_e), (beta_1, beta_2)) = prover.compute_ova_final_instance();
+
+        let circuit_w = build_w(&prover, &beta);
+        let circuit_e = build_e(&prover, &beta);
+
+        let (
+            (final_cycle_fold_instance, _),
+            (cross_term_error_commitment_w, cross_term_error_commitment_e),
+            (beta_1, beta_2),
+        ) = prover
+            .compute_ova_final_instance_from_circuits(
+                beta,
+                transcript,
+                circuit_w.clone(),
+                circuit_e.clone(),
+            )
+            .expect("cycle-fold synthesis should not fail");
 
         let beta_1_non_native = cast_field::<G1::ScalarField, G1::BaseField>(beta_1);
         let beta_2_non_native = cast_field::<G1::ScalarField, G1::BaseField>(beta_2);
+
+        let auxiliary_input_W_var = prover
+            .synthesize_secondary_circuit(circuit_w)
+            .expect("secondary circuit synthesis should not fail")
+            .0;
+        let auxiliary_input_E_var = prover
+            .synthesize_secondary_circuit(circuit_e)
+            .expect("secondary circuit synthesis should not fail")
+            .0;
 
         NovaVerifierCircuit {
             running_instance: prover.running_accumulator.0.clone(),
@@ -171,11 +246,24 @@ where
             beta_2_non_native,
             running_ova_instance: prover.ova_running_instance.clone(),
             final_ova_instance: final_cycle_fold_instance,
-            auxiliary_input_W_var: prover.compute_ova_auxiliary_input_W(&beta).0,
-            auxiliary_input_E_var: prover.compute_ova_auxiliary_input_E(&beta).0,
+            auxiliary_input_W_var,
+            auxiliary_input_E_var,
             cross_term_error_commitment_w,
             cross_term_error_commitment_e,
         }
+    }
+
+    pub fn initialise(
+        prover: NovaProver<F, G1, G2, C1, C2>,
+    ) -> NovaVerifierCircuit<F, G1, G2, C1, C2>
+    where
+        <G2 as CurveConfig>::ScalarField: Absorb,
+    {
+        Self::initialise_with_secondary(
+            prover,
+            NovaProver::build_ova_auxiliary_input_W,
+            NovaProver::build_ova_auxiliary_input_E,
+        )
     }
 }
 
@@ -191,10 +279,26 @@ mod test {
     fn test() {
         let prover: NovaProver<F, G1, G2, C1, C2> = NovaProver::rand((10, 3, 17));
 
-        let augmented_circuit: NovaVerifierCircuit<F, G1, G2, C1, C2> = NovaVerifierCircuit::initialise(prover);
+        let augmented_circuit: NovaVerifierCircuit<F, G1, G2, C1, C2> =
+            NovaVerifierCircuit::initialise(prover);
+
+        augmented_circuit.verify();
+    }
+
+    #[test]
+    fn test_initialise_with_secondary_builder() {
+        let prover: NovaProver<F, G1, G2, C1, C2> = NovaProver::rand((10, 3, 17));
+
+        let augmented_circuit = NovaVerifierCircuit::initialise_with_secondary(
+            prover.clone(),
+            |p, beta| {
+                let mut circuit = p.build_ova_auxiliary_input_W(beta);
+                circuit.flag = true;
+                circuit
+            },
+            |p, beta| p.build_ova_auxiliary_input_E(beta),
+        );
 
         augmented_circuit.verify();
     }
 }
-
-


### PR DESCRIPTION
## Summary
- add reusable helpers on `NovaProver` to build and synthesize CycleFold secondary circuits, and allow overriding the circuits used for folding
- extend `NovaVerifierCircuit` with an `initialise_with_secondary` constructor that accepts user-provided secondary circuits while keeping the default behaviour unchanged
- cover the new helpers with unit tests for both the prover and verifier constructors

## Testing
- `cargo test --lib nova::nova::prover::test::test_secondary_synthesis_builder` *(fails: unrelated compile errors in `speedyspartan` modules)*


------
https://chatgpt.com/codex/tasks/task_e_69067e2c36c4833095e1cad5c5c3c3ea